### PR TITLE
Add daily and hourly statistics to Home view

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -269,7 +269,7 @@ export async function renderHomePage(env) {
         <div class="form-group hidden" id="repo-group">
             <label for="repo">Specific Repo</label>
             <input type="text" id="repo" placeholder="e.g. facebook/react" spellcheck="false">
-            <small class="text-muted">Please format as 'owner/repo-name'</small> 
+            <small style="color: #cccccc;">Please format as 'owner/repo-name'</small>
         </div>
 
         <div class="form-group" id="limit-group">
@@ -400,7 +400,7 @@ export async function renderHomePage(env) {
             }
             else if (type === 'hour') {
                  // Automatically detect user timezone offset (in hours)
-                 const offset = new Date().getTimezoneOffset() / -60;
+                 const offset = new Date().getTimezoneOffset();
                  params.append('offset', offset);
             }
             // 'day' type only needs username, which is already added

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -269,7 +269,7 @@ export async function renderHomePage(env) {
         <div class="form-group hidden" id="repo-group">
             <label for="repo">Specific Repo</label>
             <input type="text" id="repo" placeholder="e.g. facebook/react" spellcheck="false">
-            <small style="color: #cccccc;">Please format as 'owner/repo-name'</small>
+            <small style="color: #dbdbdb;">Please format as 'owner/repo-name'</small>
         </div>
 
         <div class="form-group" id="limit-group">
@@ -400,7 +400,7 @@ export async function renderHomePage(env) {
             }
             else if (type === 'hour') {
                  // Automatically detect user timezone offset (in hours)
-                 const offset = new Date().getTimezoneOffset();
+                 const offset = new Date().getTimezoneOffset() / -60;
                  params.append('offset', offset);
             }
             // 'day' type only needs username, which is already added

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -267,8 +267,9 @@ export async function renderHomePage(env) {
         </div>
 
         <div class="form-group hidden" id="repo-group">
-            <label>Specific Repo</label>
-            <input type="text" id="repo" placeholder="e.g. owner/repo-name" spellcheck="false">
+            <label for="repo">Specific Repo</label>
+            <input type="text" id="repo" placeholder="e.g. facebook/react" spellcheck="false">
+            <small class="text-muted">Please format as 'owner/repo-name'</small> 
         </div>
 
         <div class="form-group" id="limit-group">
@@ -379,8 +380,12 @@ export async function renderHomePage(env) {
 
             if (type === 'repo') {
                 const repo = elements.repo.value.trim();
-                if (repo) params.append('repo', repo);
-            } 
+                if (!repo) {
+                    alert("Please enter a repository name (e.g., owner/repo).");
+                    return; 
+                }
+                params.append('repo', repo);
+            }
             else if (type === 'repos') {
                 params.append('limit', elements.limit.value);
                 


### PR DESCRIPTION
This PR updates home.js to implement the display of user statistics broken down by day and hour. This enhances the dashboard by providing more granular data insights.

**Key Changes**

- Modified home.js: Added logic to calculate and render daily and hourly stats.
- UI Updates: Integrated new visual elements to display the time-based data clearly.

**Testing**

1. Verified that daily stats aggregate correctly.
2. Checked hourly breakdowns for accuracy.

Screenshots - 

<img width="1280" height="641" alt="image" src="https://github.com/user-attachments/assets/442e5b54-ce4d-47bc-9378-f9828394d8e6" />

<img width="1280" height="641" alt="image" src="https://github.com/user-attachments/assets/49138f7d-b79c-40f6-9da0-6955bee4594a" />

<img width="1280" height="636" alt="image" src="https://github.com/user-attachments/assets/52733535-8888-42a4-9b90-bca56376a139" />


~@aaditya8979

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Card Type selector (Repos, Single Repository, Contribution Days, Commits by Hour).
  * Dynamic form UI that reveals repository input only for Single Repository; CSS transitions and a hidden utility.
  * Enhanced URL generation: always includes username/type; includes repo for Single Repository, limit/sort/exclude for Repos, and timezone offset for Hour.

* **Bug Fixes**
  * More robust input handling and Enter-key behavior; UI initializes and updates reliably on type changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->